### PR TITLE
Fix/remove xqjson dependency

### DIFF
--- a/.existdb.json
+++ b/.existdb.json
@@ -1,0 +1,18 @@
+{
+    "servers": {
+        "localhost": {
+            "server": "http://localhost:8080/exist",
+            "user": "admin",
+            "password": ""
+        }
+    },
+    "sync": {
+        "server": "localhost",
+        "root": "/db/apps/demo",
+        "active": true,
+        "ignore": [
+            ".existdb.json",
+            ".git/**"
+        ]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+expath-pkg.xml

--- a/build.properties
+++ b/build.properties
@@ -4,4 +4,4 @@
 #
 
 project.name=demo
-project.version=0.3.3
+project.version=0.4.0

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,7 @@
+#
+# Don't directly modify this file. Instead, copy it to local.build.properties and
+# edit that.
+#
+
+project.name=demo
+project.version=0.3.3

--- a/build.xml
+++ b/build.xml
@@ -2,11 +2,7 @@
 <project default="all" name="eXist-db Demo Apps">
     <property file="local.build.properties"/>
     <property file="build.properties"/>
-    <property name="project.app" value="demo"/>
-    <property name="project.version" value="0.3.3"/>
-    <property name="build" value="build"/>
-    <property name="data" value="./data"/>
-    <property name="examples" value="./examples"/>
+    <property name="build" value="./build"/>
     <property name="server.url" value="http://demo.exist-db.org/exist/apps/public-repo/public/"/>
     <condition property="git.commit" value="${git.commit}" else="">
         <isset property="git.commit"/>
@@ -21,10 +17,11 @@
         <mkdir dir="${build}"/>
         <copy file="expath-pkg.xml.tmpl" tofile="expath-pkg.xml" filtering="true" overwrite="true">
             <filterset>
+                <filter token="project.name" value="${project.name}"/>
                 <filter token="project.version" value="${project.version}"/>
             </filterset>
         </copy>
-        <zip basedir="." destfile="${build}/${project.app}-${project.version}${git.commit}.xar">
+        <zip basedir="." destfile="${build}/${project.name}-${project.version}${git.commit}.xar">
             <exclude name="${build}/*"/>
             <exclude name=".git*"/>
             <exclude name="*.tmpl"/>
@@ -35,7 +32,7 @@
         <input message="Enter password:" addproperty="server.pass" defaultvalue="">
             <handler type="secure"/>
         </input>
-        <property name="xar" value="${project.app}-${project.version}${git.commit}.xar"/>
+        <property name="xar" value="${project.name}-${project.version}${git.commit}.xar"/>
         <exec executable="curl">
             <arg line="-T ${build}/${xar} -u admin:${server.pass} ${server.url}/${xar}"/>
         </exec>

--- a/examples/contacts/data/e19316b0-af33-4c1c-88e3-9ddd5b03c239.xml
+++ b/examples/contacts/data/e19316b0-af33-4c1c-88e3-9ddd5b03c239.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<contact>
+    <name>Hans</name>
+    <phone>0293829</phone>
+    <email>hans@web.de</email>
+    <id link-type="self">e19316b0-af33-4c1c-88e3-9ddd5b03c239</id>
+</contact>

--- a/examples/contacts/js/app.js
+++ b/examples/contacts/js/app.js
@@ -59,8 +59,8 @@ contactsApp.controller('newContact',
                 $http
                     .defaults
                     .headers
-                    .post['Content-Type'] = 'application/exist+json'; //TODO: fix this non-standard content type
-                
+                    .post['Content-Type'] = 'application/json';
+
                 $http
                     .post('/exist/restxq/demo/contacts',
                     { 

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -2,6 +2,5 @@
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/demo" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>eXist-db Demo Apps</title>
     <dependency package="http://exist-db.org/apps/shared" semver-min="0.4.0"/>
-    <dependency package="http://xqilla.sourceforge.net/pkg/xqjson"/>
-    <dependency processor="http://exist-db.org" semver-min="2.2.1"/>
+    <dependency processor="http://exist-db.org" semver-min="3.0.4"/>
 </package>

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/demo" abbrev="demo" version="@project.version@" spec="1.0">
+<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/demo" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>eXist-db Demo Apps</title>
     <dependency package="http://exist-db.org/apps/shared" semver-min="0.4.0"/>
     <dependency package="http://xqilla.sourceforge.net/pkg/xqjson"/>

--- a/repo.xml
+++ b/repo.xml
@@ -14,6 +14,7 @@
     <changelog>
         <change version="0.4.0">
             <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Improved the display of search results in the content extraction demo.</li>
                 <li>Fixed RESTXQ and AngularJS demo.</li>
                 <li>Removed dependency on JSONXQ library, replaced with XQuery 3.1 JSON facility.</li>
             </ul>

--- a/repo.xml
+++ b/repo.xml
@@ -11,4 +11,12 @@
     <prepare>pre-install.xql</prepare>
     <finish>post-install.xql</finish>
     <permissions xmlns:repo="http://exist-db.org/xquery/repo" password="demo" user="demo" group="demo" mode="0775"/>
+    <changelog>
+        <change version="0.4.0">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Fixed RESTXQ and AngularJS demo.</li>
+                <li>Removed dependency on JSONXQ library, replaced with XQuery 3.1 JSON facility.</li>
+            </ul>
+        </change>
+    </changelog>
 </meta>

--- a/repo.xml
+++ b/repo.xml
@@ -2,7 +2,7 @@
 <meta xmlns="http://exist-db.org/xquery/repo">
     <description>Various small demo applications.</description>
     <author>Wolfgang Meier</author>
-    <website/>
+    <website>https://github.com/eXist-db/demo-apps</website>
     <status>beta</status>
     <license>GNU-LGPL</license>
     <copyright>true</copyright>


### PR DESCRIPTION
This does more than remove the xqjson dependency. The restxq/angularjs demo that used xqjson was broken - because the previously-registered `http` namespace (associated with the expath http client) was switched to `hc` (this wasn't noted in any release notes, was it?). I switched completely over to json parsing, since eXist doesn't yet support the `fn:json-to-xml()` function which would've been a closer drop-in replacement.

Tested and confirmed that it worked. 

The biggest thing that doesn't work is updating the built-in contact record, e.g., hitting Delete at http://localhost:8080/exist/apps/demo/examples/contacts/html/home.html?browseContacts#/browseContacts: 

> java:org.exist.security.PermissionDeniedException:User 'guest' does not have permission to write to the document '/db/apps/demo/examples/contacts/data/e19316b0-af33-4c1c-88e3-9ddd5b03c239.xml'!

Adding new contact records works, but updates of contact records do not go through - though there is no error. I can't figure that out. 

But on balance this fixes bugs and relieves us of the dependency on xqjson. The use of the XQuery 3.1 features (namely, `fn:parse-json()`) does mean removing support for eXist 2.2. Now the semver minimum is eXist 3.0.4.